### PR TITLE
Remove indexed

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ contract FungibleTokenInterface =
     , decimals : int }
     
   datatype event =
-    Transfer(indexed address, indexed address, indexed int)
+    Transfer(address, address, int)
 
   entrypoint aex9_extensions : () => list(string)
   entrypoint meta_info : () => meta_info
@@ -159,7 +159,7 @@ This event MUST be triggered and emitted when tokens are transferred, including 
 The transfer event arguments should be as follows: `(from_account, to_account, value)`
 
 ```text
-Transfer(indexed address, indexed address, indexed int)
+Transfer(address, address, int)
 ```
 
 | parameter | type |
@@ -197,7 +197,7 @@ stateful entrypoint mint(account: address, value: int) : ()
 The mint event arguments should be as follows: `(account,  value)`
 
 ```text
-Mint(indexed address, indexed int)
+Mint(address, int)
 ```
 
 | parameter | type |
@@ -226,7 +226,7 @@ stateful entrypoint burn(value: int) : ()
 The burn event arguments should be as follows: `(account,  value)`
 
 ```text
-Burn(indexed address, indexed int)
+Burn(address, int)
 ```
 
 | parameter | type |
@@ -294,7 +294,7 @@ record allowance_accounts =
 The approval event arguments should be as follows: `(from_account, for_account, value)`
 
 ```text
-Allowance(indexed address, indexed address, indexed int)
+Allowance(address, address, int)
 ```
 
 | parameter | type |
@@ -354,7 +354,7 @@ stateful entrypoint swapped() : map(address, int)
 The swap event arguments should be as follows: `(account,  value)`
 
 ```text
-Swap(indexed address, indexed int)
+Swap(address, int)
 ```
 
 | parameter | type |

--- a/contracts/extensions/allowances.aes
+++ b/contracts/extensions/allowances.aes
@@ -28,10 +28,10 @@
 
   // This is a type alias for the allowances map
   type allowances = map(allowance_accounts, int)
+  
   // Declaration and structure of datatype event
   // and events that will be emitted on changes
-  datatype event =
-    Allowance(indexed address, indexed address, indexed int)
+  datatype event = Allowance(address, address, int)
 
   // and set the inital smart contract state
   entrypoint init() =

--- a/contracts/extensions/burnable.aes
+++ b/contracts/extensions/burnable.aes
@@ -18,7 +18,7 @@
 // THIS IS NOT SECURITY AUDITED
 // DO NEVER USE THIS WITHOUT SECURITY AUDIT FIRST
 
-  datatype event = Burn(indexed address, indexed int)
+  datatype event = Burn(address, int)
 
   // Destroys `value` tokens from `Call.caller`, reducing the total supply.
   // `Burn` event with `Call.caller` address and `value`.

--- a/contracts/extensions/mintable.aes
+++ b/contracts/extensions/mintable.aes
@@ -18,7 +18,7 @@
 // THIS IS NOT SECURITY AUDITED
 // DO NEVER USE THIS WITHOUT SECURITY AUDIT FIRST
 
-  datatype event = Mint(indexed address, indexed int)
+  datatype event = Mint(address, int)
 
   // Creates `value` tokens and assigns them to `account`, increasing the total supply.
   // Emits a `Mint` event with `account` and `value`.

--- a/contracts/fungible-token-full-interface.aes
+++ b/contracts/fungible-token-full-interface.aes
@@ -10,11 +10,11 @@ contract FungibleTokenFullInterface =
   type allowances = map(allowance_accounts, int)
 
   datatype event =
-    Transfer(indexed address, indexed address, indexed int)
-    | Allowance(indexed address, indexed address, indexed int)
-    | Burn(indexed address, indexed int)
-    | Mint(indexed address, indexed int)
-    | Swap(indexed address, indexed int)
+    Transfer(address, address, int)
+    | Allowance(address, address, int)
+    | Burn(address, int)
+    | Mint(address, int)
+    | Swap(address, int)
 
   entrypoint aex9_extensions      : ()                      => list(string)
   entrypoint meta_info            : ()                      => meta_info

--- a/contracts/fungible-token-full.aes
+++ b/contracts/fungible-token-full.aes
@@ -50,11 +50,11 @@ contract FungibleTokenFull =
   // Declaration and structure of datatype event
   // and events that will be emitted on changes
   datatype event =
-    Transfer(indexed address, indexed address, indexed int)
-    | Allowance(indexed address, indexed address, indexed int)
-    | Burn(indexed address, indexed int)
-    | Mint(indexed address, indexed int)
-    | Swap(indexed address, indexed int)
+    Transfer(address, address, int)
+    | Allowance(address, address, int)
+    | Burn(address, int)
+    | Mint(address, int)
+    | Swap(address, int)
 
   // List of supported extensions
   entrypoint aex9_extensions() : list(string) = ["allowances", "mintable", "burnable", "swappable"]

--- a/contracts/fungible-token-interface.aes
+++ b/contracts/fungible-token-interface.aes
@@ -7,7 +7,7 @@ contract FungibleTokenInterface =
     , decimals : int }
 
   datatype event =
-    Transfer(indexed address, indexed address, indexed int)
+    Transfer(address, address, int)
 
   entrypoint aex9_extensions : ()             => list(string)
   entrypoint meta_info       : ()             => meta_info

--- a/contracts/fungible-token.aes
+++ b/contracts/fungible-token.aes
@@ -41,8 +41,7 @@ contract FungibleToken =
 
   // Declaration and structure of datatype event
   // and events that will be emitted on changes
-  datatype event =
-    Transfer(indexed address, indexed address, indexed int)
+  datatype event = Transfer(address, address, int)
 
 
   // List of implemented extensions for the deployed contract


### PR DESCRIPTION
- This removes the `indexed` keyword used in the `event`s used in both the basic token and extensions.
- The keyword is not needed anymore as all the arguments of an event are indexed by default.
- Updated documentation to affect the changes.